### PR TITLE
Never require auth for API requests

### DIFF
--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -83,7 +83,7 @@ module Spree
       end
 
       def requires_authentication?
-        Spree::Api::Config[:requires_authentication]
+        false
       end
 
       def not_found


### PR DESCRIPTION
This fixes
https://github.com/openfoodfoundation/openfoodnetwork/issues/1900 and
https://github.com/openfoodfoundation/openfoodnetwork/issues/1965 and
explained in
https://github.com/openfoodfoundation/openfoodnetwork/pull/1984.

For unknown reasons `Spree::Api::Config[:requires_authentication]`
gets set to `true` somewhere between the boot and the execution of the
tests making them fail. Spree itself however, sets it to false.

This patch serves as temporal fix until in an upcoming Spree version the API
authentication does work.