### PR TITLE
Before save hook

### DIFF
--- a/core/app/models/null_decorator.rb
+++ b/core/app/models/null_decorator.rb
@@ -1,0 +1,4 @@
+require 'delegate'
+
+class NullDecorator < SimpleDelegator
+end

--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -109,12 +109,14 @@ module Spree
       @searcher_class = sclass
     end
 
-    def package_factory=(factory)
-      @package_factory = factory
-    end
+    attr_writer :package_factory, :order_updater_decorator
 
     def package_factory
       @package_factory ||= Spree::Stock::Package
+    end
+
+    def order_updater_decorator
+      @order_updater_decorator ||= NullDecorator
     end
   end
 end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -378,6 +378,7 @@ module Spree
       end
 
       updater.update_shipment_state
+      updater.before_save_hook
       save
       updater.run_hooks
 

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -223,7 +223,9 @@ module Spree
     end
 
     def updater
-      @updater ||= OrderUpdater.new(self)
+      @updater ||= Spree::Config.order_updater_decorator.new(
+        Spree::OrderUpdater.new(self)
+      )
     end
 
     def update!

--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -125,6 +125,10 @@ module Spree
       choose_best_promotion_adjustment
     end
 
+    def before_save_hook
+      # no op
+    end
+
     private
 
       # Picks one (and only one) promotion to be eligible for this order

--- a/core/spec/models/spree/app_configuration_spec.rb
+++ b/core/spec/models/spree/app_configuration_spec.rb
@@ -32,5 +32,18 @@ describe Spree::AppConfiguration do
       prefs.package_factory.should eq TestPackageFactory
     end
   end
-end
 
+  it 'uses Spree::NullDecorator by default' do
+    prefs.order_updater_decorator = nil
+    prefs.order_updater_decorator.should eq Spree::NullDecorator
+  end
+
+  context 'when an order_updater_decorator is specified' do
+    class FakeOrderUpdaterDecorator; end
+
+    it 'uses the set order_updater_decorator' do
+      prefs.order_updater_decorator = FakeOrderUpdaterDecorator
+      prefs.order_updater_decorator.should eq FakeOrderUpdaterDecorator
+    end
+  end
+end

--- a/core/spec/models/spree/null_decorator_spec.rb
+++ b/core/spec/models/spree/null_decorator_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe NullDecorator do
+  class FakeDecorated; end
+
+  let(:decorated) { FakeDecorated.new }
+
+  it 'receives an object to decorate in its constructor' do
+    described_class.new(decorated).should be_true
+  end
+end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -206,6 +206,11 @@ describe Spree::Order do
       order.state_changes.should_receive(:create).exactly(3).times #order, shipment & payment state changes
       order.finalize!
     end
+
+    it 'calls updater#before_save' do
+      order.updater.should_receive(:before_save_hook)
+      order.finalize!
+    end
   end
 
   context "#process_payments!" do

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -577,5 +577,26 @@ describe Spree::Order do
       order.finalize!
     end
   end
-end
 
+  context '#updater' do
+    class FakeOrderUpdaterDecorator
+      attr_reader :decorated_object
+
+      def initialize(decorated_object)
+        @decorated_object = decorated_object
+      end
+    end
+
+    before do
+      Spree::Config.stub(:order_updater_decorator) { FakeOrderUpdaterDecorator }
+    end
+
+    it 'returns an order_updater_decorator class' do
+      order.updater.class.should == FakeOrderUpdaterDecorator
+    end
+
+    it 'decorates a Spree::OrderUpdater' do
+      order.updater.decorated_object.class.should == Spree::OrderUpdater
+    end
+  end
+end


### PR DESCRIPTION
## What

This adds an extension hook to implement https://github.com/openfoodfoundation/openfoodnetwork/issues/2287 by means of:

* A new `order_updater_decorator` configuration key
* A new `#before_save_hook` method to the public API of `OrderUpdater` but empty

The former allows us to provide a custom `OrderUpdater` from OFN's codebase that does provide a non-empty implementation for `#before_save_hook`.

Within that method, we can do things like updating the order's `ship_address` according to OFN's business logic. Said changes will be persisted right after in line :382 by the order model itself.

### Naming

I decided to name the hook `before_save_hook` to make it clear it is not related to ActiveModel's callbacks but an OFN's thing. I believe this distinction will be important when someone reads this code again.

