### PR TITLE
Fix "Validation failed: Card has expired"

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ Branched off of v2.0.4 it contains the following extra commits:
 * [3fd1535](https://github.com/spree/spree/commit/3fd1535e75d383fa7119d2f3b985f8c12731302c):
     Introduced in [#2252](https://github.com/openfoodfoundation/openfoodnetwork/pull/2252) to fix an
     error that prevented the app from booting.
+* [002b725d1..e27805789](https://github.com/spree/spree/commit/7b6045085f9aebcd2f0d7ba73fc8867b80e07ca3#diff-1e88c46e0e0d3d6469c50c9be98ba2a1)
+    Introduced in [#7](https://github.com/openfoodfoundation/spree/pull/7) to
+    have a valid credit card factory and thus have tests passing.
 
 [![Code Climate](https://codeclimate.com/github/spree/spree.png)](https://codeclimate.com/github/spree/spree)
 

--- a/core/lib/spree/testing_support/factories/credit_card_factory.rb
+++ b/core/lib/spree/testing_support/factories/credit_card_factory.rb
@@ -7,7 +7,7 @@ FactoryGirl.define do
   factory :credit_card, class: TestCard do
     verification_value 123
     month 12
-    year 2013
+    year { Date.year }
     number '4111111111111111'
   end
 end

--- a/core/lib/spree/testing_support/factories/credit_card_factory.rb
+++ b/core/lib/spree/testing_support/factories/credit_card_factory.rb
@@ -7,7 +7,7 @@ FactoryGirl.define do
   factory :credit_card, class: TestCard do
     verification_value 123
     month 12
-    year { Date.year }
+    year { Time.now.year }
     number '4111111111111111'
   end
 end

--- a/core/lib/spree/testing_support/factories/credit_card_factory.rb
+++ b/core/lib/spree/testing_support/factories/credit_card_factory.rb
@@ -7,7 +7,7 @@ FactoryGirl.define do
   factory :credit_card, class: TestCard do
     verification_value 123
     month 12
-    year { Time.now.year }
+    year { Time.now.year + 1 }
     number '4111111111111111'
   end
 end

--- a/core/spec/models/spree/credit_card_spec.rb
+++ b/core/spec/models/spree/credit_card_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Spree::CreditCard do
 
-  let(:valid_credit_card_attributes) { { number: '4111111111111111', verification_value: '123', month: 12, year: 2014 } }
+  let(:valid_credit_card_attributes) { { number: '4111111111111111', verification_value: '123', month: 12, year: Time.now.year + 1 } }
 
   def self.payment_states
     Spree::Payment.state_machine.states.keys


### PR DESCRIPTION
## What?

Closes https://github.com/openfoodfoundation/openfoodnetwork/issues/2449

We need a passing test suite to move code around confidently. Also, it was an agreement of the last [catch-up](https://github.com/openfoodfoundation/openfoodnetwork/wiki/Team-catch-ups--%F0%9F%92%AC#notes--agreement).

* Added https://github.com/openfoodfoundation/spree/pull/6/commits/002b725d158edc9fc7aa111ec41f92e589f2518d and https://github.com/openfoodfoundation/spree/pull/6/commits/e278057899961eb44031ebaa46d289ce1c0017e0 to get `payments_controller_spec.rb` to pass. It was all due to having credit card factory expire on 2013... drawbacks of resurrecting code from 5 years ago...