### PR TITLE
Fix ability to set on_demand to false and on_hand

### DIFF
--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -58,7 +58,7 @@ module Spree
       if !Spree::Config[:track_inventory_levels]
         raise 'Cannot set on_hand value when Spree::Config[:track_inventory_levels] is false'
       else
-        self.count_on_hand = new_level unless self.on_demand
+        self.count_on_hand = new_level
       end
     end
 


### PR DESCRIPTION
When setting `on_demand` to false and also entering a value for
`on_hand` the guard was restricting the setting of the value because
`on_demand` was not yet changed.

Since we guard against the showing of the `on_hand` value by checking
the `on_demand` value there is no harm in allowing this value to be
updated. Currently the previous `unit_on_hand` value is still set in the
database and that is what gets shown to the user after an update occurs.

Fixes https://github.com/openfoodfoundation/openfoodnetwork/issues/2351