### PR TITLE
Update selenium-webdriver and use webdrivers gem to support recent versions of Firefox

### DIFF
--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -16,6 +16,7 @@ end
 ENV["RAILS_ENV"] ||= 'test'
 require File.expand_path("../dummy/config/environment", __FILE__)
 require 'rspec/rails'
+require 'webdrivers'
 
 # Requires supporting files with custom matchers and macros, etc,
 # in ./support/ and its subdirectories.

--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -24,9 +24,10 @@ group :test do
   gem 'launchy'
   gem 'pry'
   gem 'rspec-rails', '~> 2.14.0'
-  gem 'selenium-webdriver', '~> 2.33'
+  gem 'selenium-webdriver'
   gem 'simplecov'
   gem 'webmock', '1.8.11'
+  gem "webdrivers", "~> 3.0"
 end
 
 gemspec


### PR DESCRIPTION
#### What? Why?
Closes https://github.com/openfoodfoundation/openfoodnetwork/issues/2531

Update of Selenium WebDriver dependency from 2.54 to 3.14 to fit newer versions of Firefox. 
[Webdrivers](https://github.com/titusfortner/webdrivers) gem is used to have all the needed drivers for Selenium. This fixes from the error `Selenium::WebDriver::Error::WebDriverError:  Unable to find Mozilla geckodriver.` occuring when updating selenium-webdriver.

#### What should we test?
The tests using selenium-webdriver run without failing with `Unable to establish stable firefox connection` or `Unable to find Mozilla geckodriver.`. 

#### Release notes
In order to fix Spree 2-0-4-stable test suite, `selenium-webdriver` has been updated and driver support was added. 

#### Dependencies
This is related to `selenium-webdriver` gem.