### PR TITLE
[Spree build] Fix 'element is not clickable' failures

### DIFF
--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -155,7 +155,7 @@ describe "Order Details", js: true do
             fill_in "order_bill_address_attributes_zipcode", :with => "20814"
             fill_in "order_bill_address_attributes_phone", :with => "301-444-5002"
             select2 "Alabama", :from => "State"
-            select2 "United States of Foo", :from => "Country"
+            select2 "United States of America", :from => "Country"
             click_icon :refresh
 
             click_link "Order Details"

--- a/backend/spec/features/admin/orders/shipments_spec.rb
+++ b/backend/spec/features/admin/orders/shipments_spec.rb
@@ -44,7 +44,7 @@ describe "Shipments" do
       page.should have_selector("#shipment_#{order.shipments.first.id}")
 
       within_row(2) { click_icon 'resize-horizontal' }
-      targetted_select2 "LA(#{order.reload.shipments.last.number})", from: '#s2id_item_stock_location'
+      targetted_select2 "NY Warehouse(100)", from: '#s2id_item_stock_location'
       click_icon :ok
       wait_for_ajax
       page.should have_selector("#shipment_#{order.reload.shipments.last.id}")

--- a/backend/spec/features/admin/products/stock_management_spec.rb
+++ b/backend/spec/features/admin/products/stock_management_spec.rb
@@ -73,7 +73,7 @@ describe "Stock Management" do
         click_link "Stock Management"
 
         fill_in "stock_movement_quantity", with: 5
-        select2 "default", from: "Stock Location"
+        select2 "Default", from: "Stock Location"
         click_button "Add Stock"
 
         page.should have_content('successfully created')
@@ -87,7 +87,7 @@ describe "Stock Management" do
         click_link "Stock Management"
 
         fill_in "stock_movement_quantity", with: -5
-        select2 "default", from: "Stock Location"
+        select2 "Default", from: "Stock Location"
         click_button "Add Stock"
 
         page.should have_content('successfully created')
@@ -101,7 +101,7 @@ describe "Stock Management" do
         click_link "Stock Management"
 
         fill_in "stock_movement_quantity", with: -5
-        select2 "default", from: "Stock Location"
+        select2 "Default", from: "Stock Location"
         click_button "Add Stock"
 
         page.should have_content('successfully created')


### PR DESCRIPTION
#### What? Why?

Closes https://github.com/openfoodfoundation/openfoodnetwork/issues/2532

`Selenium::WebDriver element is not clickable` failures were caused by mistakes in elements to be selected in select2 form elements (the elements passed in the tests didn't fit the elements in the collection).

I changed it to the right syntax, now they pass.

#### What should we test?

From Spree backend specs, tests don't fail on `Selenium::WebDriver element is not clickable at point (...)` anymore.