### PR TITLE
[Spree build] Wrong number of arguments for Spree::Config.package_factory

### DIFF
--- a/core/spec/models/spree/app_configuration_spec.rb
+++ b/core/spec/models/spree/app_configuration_spec.rb
@@ -27,6 +27,12 @@ describe Spree::AppConfiguration do
   context 'when a package factory is specified' do
     class TestPackageFactory; end
 
+    around do |example|
+      default_factory = prefs.package_factory
+      example.run
+      prefs.package_factory = default_factory
+    end
+
     it 'uses the set package factory' do
       prefs.package_factory = TestPackageFactory
       prefs.package_factory.should eq TestPackageFactory

--- a/core/spec/models/spree/stock/coordinator_spec.rb
+++ b/core/spec/models/spree/stock/coordinator_spec.rb
@@ -18,7 +18,6 @@ module Spree
 
       context "build packages" do
         it "builds a package for every stock location" do
-          pending '[Spree build] Failing spec'
           subject.packages.count == StockLocation.count
         end
 
@@ -26,7 +25,6 @@ module Spree
           let!(:another_location) { create(:stock_location, propagate_all_variants: false) }
 
           it "builds packages only for valid stock locations" do
-            pending '[Spree build] Failing spec'
             subject.build_packages.count.should == (StockLocation.count - 1)
           end
         end


### PR DESCRIPTION
#### What ? Why ?

Closes https://github.com/openfoodfoundation/openfoodnetwork/issues/2538

Some other tests were setting `Spree::Config.package_factory` to a custom class called `TestPackageFactory` defined in a spec file (`app_configuration_spec.rb`) and which takes no arguments. This custom class was later wrongfully used by the tests in `coordinator_spec.rb`, making them fail. 

I use rspec `around` hook in `app_configuration_spec.rb` to set the prefs, run the example, and reset them to default `Spree::Stock::Package` afterwards.