### PR TITLE
Use ActiveMerchant::ConnectionError properly for new versions

### DIFF
--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -511,8 +511,9 @@ describe Spree::Payment do
 
       context "when there is an error connecting to the gateway" do
         it "should call gateway_error " do
-          pending '[Spree build] Failing spec'
-          gateway.should_receive(:create_profile).and_raise(ActiveMerchant::ConnectionError)
+          message = double("gateway_error")
+          connection_error = ActiveMerchant::ConnectionError.new(message, nil)
+          expect(gateway).to receive(:create_profile).and_raise(connection_error)
           lambda { Spree::Payment.create({:amount => 100, :order => order, :source => card, :payment_method => gateway}, :without_protection => true) }.should raise_error(Spree::Core::GatewayError)
         end
       end


### PR DESCRIPTION
#### What ? Why ?

Closes https://github.com/openfoodfoundation/openfoodnetwork/issues/2535

The error was coming from a difference on activemerchant version that can be found in Spree 2-0-4-stable Gemfile.lock and the one used in ours. 

Forcing ActiveMerchant version to a previous one would raise conflicts with OFN, so I used ConnectionError properly for > 1.78.x.