### PR TITLE
Fix impossible to duplicate products with images

### DIFF
--- a/core/lib/spree/core/product_duplicator.rb
+++ b/core/lib/spree/core/product_duplicator.rb
@@ -44,7 +44,9 @@ module Spree
     end
 
     def duplicate_image(image)
-      image.dup.assign_attributes(:attachment => image.attachment.clone)
+      new_image = image.dup
+      new_image.assign_attributes(:attachment => image.attachment.clone)
+      new_image
     end
 
     def reset_properties


### PR DESCRIPTION
#### What ? Why ?
Closes https://github.com/openfoodfoundation/openfoodnetwork/issues/2756

This is a fix for OFN's 2756 "Impossible to duplicate products". The `duplicate_image` method was returning nil, making the duplication fail.

This fix is an implementation of Spree 2-0-stable behavior, as seen here: 
https://github.com/spree/spree/blob/3c46d141c5cb2bedced63596178a0a79df3f0c9e/core/lib/spree/core/product_duplicator.rb#L60

It comes with two new specs testing the duplication of products with image, commited to OFN master:
https://github.com/openfoodfoundation/openfoodnetwork/pull/3022


#### What should we test ?
When duplicating a product with image, it should work properly.