### PR TITLE
Remove Order#shipment memoization

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Branched off of Spree's v2.0.4, it contains the following extra commits:
 * [002b725d1..e27805789](https://github.com/spree/spree/commit/7b6045085f9aebcd2f0d7ba73fc8867b80e07ca3#diff-1e88c46e0e0d3d6469c50c9be98ba2a1)
     Introduced in [#7](https://github.com/openfoodfoundation/spree/pull/7) to
     have a valid credit card factory and thus have tests passing.
+* [c74ac05](https://github.com/openfoodfoundation/spree/pull/38/commits/c74ac05467830b942589df68c2d929abd3453597)
+    Introduced in [#38](https://github.com/openfoodfoundation/spree/pull/38/) to retrieve the appropriate shipment after changing an order's shipments.
 
 [![Code Climate](https://codeclimate.com/github/spree/spree.png)](https://codeclimate.com/github/spree/spree)
 

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -301,7 +301,7 @@ module Spree
 
     def shipment
       ActiveSupport::Deprecation.warn("[SPREE] Spree::Order#shipment is typically incorrect due to multiple shipments and will be deprecated in Spree 2.1, please process Spree::Order#shipments instead.")
-      @shipment ||= shipments.last
+      shipments.last
     end
 
     def shipped_shipments


### PR DESCRIPTION
If the shipments association changes, `#shipment` returns stale data. Since the order object, we might be using is still alive, its @shipment ivar still holds an old shipment object (it's not nil) and thus `@shipment ||= shipments.last` doesn't evaluate the right-hand side of the expression.