### PR TITLE
Make Splitter::Base.build_package and Shipment.to_package use Config::package_factory

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -222,7 +222,7 @@ module Spree
     end
 
     def to_package
-      package = Stock::Package.new(stock_location, order)
+      package = Spree::Config.package_factory.new(stock_location, order)
       inventory_units.includes(:variant).each do |inventory_unit|
         package.add inventory_unit.variant, 1, inventory_unit.state_name
       end

--- a/core/app/models/spree/stock/packer.rb
+++ b/core/app/models/spree/stock/packer.rb
@@ -1,7 +1,7 @@
 module Spree
   module Stock
     class Packer
-      attr_reader :stock_location, :order, :splitters
+      attr_reader :stock_location, :order, :splitters, :package_factory
 
       def initialize(stock_location, order, splitters=[Splitter::Base])
         @stock_location = stock_location
@@ -27,8 +27,6 @@ module Spree
       end
 
       private
-
-      attr_reader :package_factory
 
       def build_splitter
         splitter = nil

--- a/core/app/models/spree/stock/splitter/base.rb
+++ b/core/app/models/spree/stock/splitter/base.rb
@@ -15,12 +15,13 @@ module Spree
         end
 
         private
+
         def return_next(packages)
           next_splitter ? next_splitter.split(packages) : packages
         end
 
         def build_package(contents=[])
-          Spree::Stock::Package.new(stock_location, order, contents)
+          @packer.package_factory.new(stock_location, order, contents)
         end
       end
     end

--- a/core/spec/models/spree/stock/splitter/base_spec.rb
+++ b/core/spec/models/spree/stock/splitter/base_spec.rb
@@ -15,6 +15,22 @@ module Spree
           splitter2.split(packages)
         end
 
+        it 'builds package using package factory' do
+          # Basic extension of Base splitter used to test build_package method
+          class ::BasicSplitter < Base
+            def split(packages)
+              build_package
+            end
+          end
+
+          # Custom package used to test setting package factory
+          class ::CustomPackage
+            def initialize(stock_location, order, splitters); end
+          end
+          allow(Spree::Config).to receive(:package_factory) { CustomPackage }
+
+          expect(::BasicSplitter.new(packer).split(nil).class).to eq CustomPackage
+        end
       end
     end
   end


### PR DESCRIPTION
This PR fixes: https://github.com/openfoodfoundation/openfoodnetwork/issues/3607

#### Description
This PR is related to https://github.com/coopdevs/spree/pull/6
We are replacing the usage of Spree::Stock::Package with a call to the package factory.
In both cases below, for OFN, the shipping methods were not being filtered by distributor, which is done in the OFN package implementation injected in package_factory.

#### Splitter::Base
The change in Splitter::Base makes all splitters use the injected Package, not the default Spree Package class when building the split packages. This was breaking all splitters that required the custom package factory.

This is related to https://github.com/openfoodfoundation/openfoodnetwork/pull/3604
This has no impact on OFN after 3604 because this build_package method is called by all splitters _except_ the Base splitter which is the only one that OFN will use for now.

#### Shipment.to_package
The change in Shipment.to_package uses the injected Package factory to convert every shipment to a package.
This was creating a bug in OFN during order.refresh_rates that happens when loading shipping_methods in the order edit page. See https://github.com/openfoodfoundation/openfoodnetwork/issues/3607