### PR TITLE
Update aws-sdk back to 1.11.1

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'activemerchant', '~> 1.34'
   s.add_dependency 'acts_as_list', '= 0.2.0'
   s.add_dependency 'awesome_nested_set', '2.1.5'
-  s.add_dependency 'aws-sdk', '~> 1.3.4'
+  s.add_dependency 'aws-sdk', '~> 1.11.1'
   s.add_dependency 'cancan', '~> 1.6.10'
   s.add_dependency 'deface', '>= 0.9.1'
   s.add_dependency 'ffaker', '~> 1.16'


### PR DESCRIPTION
This was done already in the past in the ofn spree fork here https://github.com/openfoodfoundation/spree/commit/6c98889f7453983da874b89d842e1945438bb6d0
aws-sdk 1.11.1 is already being used in both master and 2-0-4-stable on the OFN gemfile.lock

This will be followed up by https://github.com/openfoodfoundation/openfoodnetwork/pull/3717