### PR TITLE
Handle soft deleted variants in order edit

### DIFF
--- a/core/app/models/spree/inventory_unit.rb
+++ b/core/app/models/spree/inventory_unit.rb
@@ -53,6 +53,11 @@ module Spree
         variant_id: variant_id).first
     end
 
+    # Remove variant default_scope `deleted_at: nil`
+    def variant
+      Spree::Variant.unscoped { super }
+    end
+
     private
 
       def allow_ship?

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -158,7 +158,7 @@ module Spree
     end
 
     def manifest
-      inventory_units.includes(:variant).group_by(&:variant).map do |variant, units|
+      inventory_units.joins(:variant).includes(:variant).group_by(&:variant).map do |variant, units|
         states = {}
         units.group_by(&:state).each { |state, iu| states[state] = iu.count }
         OpenStruct.new(variant: variant, quantity: units.length, states: states)

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -223,7 +223,7 @@ module Spree
 
     def to_package
       package = Spree::Config.package_factory.new(stock_location, order)
-      inventory_units.includes(:variant).each do |inventory_unit|
+      inventory_units.joins(:variant).includes(:variant).each do |inventory_unit|
         package.add inventory_unit.variant, 1, inventory_unit.state_name
       end
       package

--- a/core/spec/models/spree/inventory_unit_spec.rb
+++ b/core/spec/models/spree/inventory_unit_spec.rb
@@ -61,6 +61,11 @@ describe Spree::InventoryUnit do
       unit.variant.destroy
       expect(unit.reload.variant).to be_a Spree::Variant
     end
+
+    it "can still fetch variants by eager loading (remove default_scope)" do
+      unit.variant.destroy
+      expect(Spree::InventoryUnit.joins(:variant).includes(:variant).first.variant).to be_a Spree::Variant
+    end
   end
 
   context "#finalize_units!" do

--- a/core/spec/models/spree/inventory_unit_spec.rb
+++ b/core/spec/models/spree/inventory_unit_spec.rb
@@ -52,6 +52,17 @@ describe Spree::InventoryUnit do
     end
   end
 
+  context "variants deleted" do
+    let!(:unit) do
+      Spree::InventoryUnit.create(variant: stock_item.variant)
+    end
+
+    it "can still fetch variant" do
+      unit.variant.destroy
+      expect(unit.reload.variant).to be_a Spree::Variant
+    end
+  end
+
   context "#finalize_units!" do
     let!(:stock_location) { create(:stock_location) }
     let(:variant) { create(:variant) }


### PR DESCRIPTION
## Description

This deals with https://github.com/openfoodfoundation/openfoodnetwork/issues/3903 by overcoming the `default_scope` recently added in v2.

This brings the Spree patch introduced by https://github.com/spree/spree/pull/3628. I tried to stick to Spree's commits as much as possible so we don't reinvent the wheel and maintain less code. No need to do it differently ourselves if we'll need to go through these Spree commits sooner or later.

This makes use of a little trick (bug) of ActiveRecord as the author mentions in the original commit

> Deleted variants were not being fetched due to a default scope. Adding a
`joins` seems to override the default scope and fix exceptions in
backend when trying to view orders with deleted variants

Looks like said bug got fixed in Rails 4.0.1 but the same author fixed it as well in https://github.com/spree/spree/commit/4e8ba7524a819ec116bd2569e7a86686ead21c94. We'll need to be aware of it.