### PR TITLE
Remove deface from spree core dependencies (target spree 2.0.4)

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'awesome_nested_set', '2.1.5'
   s.add_dependency 'aws-sdk', '~> 1.11.1'
   s.add_dependency 'cancan', '~> 1.6.10'
-  s.add_dependency 'deface', '>= 0.9.1'
   s.add_dependency 'ffaker', '~> 1.16'
   s.add_dependency 'highline', '= 1.6.18' # Necessary for the install generator
   s.add_dependency 'httparty', '~> 0.11' # For checking alerts.


### PR DESCRIPTION
deface is not needed in our use of spree core and in none of the spree deps we have right now:
gem 'spree_i18n', github: 'spree/spree_i18n', branch: '1-3-stable'
gem 'spree_paypal_express', github: "openfoodfoundation/better_spree_paypal_express", branch: "2-0-stable"
