### PR TITLE
Change Spree::Payment processing methods to use strict creation

### DIFF
--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -93,7 +93,7 @@ module Spree
           record_response(response)
 
           if response.success?
-            self.class.create(
+            self.class.create!(
               :order => order,
               :source => self,
               :payment_method => payment_method,
@@ -169,7 +169,7 @@ module Spree
       end
 
       def record_response(response)
-        log_entries.create(:details => response.to_yaml)
+        log_entries.create!(:details => response.to_yaml)
       end
 
       def protect_from_connection_error

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -38,7 +38,7 @@ describe Spree::Payment do
 
   before(:each) do
     # So it doesn't create log entries every time a processing method is called
-    payment.log_entries.stub(:create)
+    payment.log_entries.stub(:create!)
   end
 
   context 'validations' do
@@ -127,7 +127,7 @@ describe Spree::Payment do
       end
 
       it "should log the response" do
-        payment.log_entries.should_receive(:create).with(:details => anything)
+        payment.log_entries.should_receive(:create!).with(:details => anything)
         payment.authorize!
       end
 
@@ -178,7 +178,7 @@ describe Spree::Payment do
       end
 
       it "should log the response" do
-        payment.log_entries.should_receive(:create).with(:details => anything)
+        payment.log_entries.should_receive(:create!).with(:details => anything)
         payment.purchase!
       end
 
@@ -264,7 +264,7 @@ describe Spree::Payment do
         it "should do nothing" do
           payment.should_not_receive(:complete)
           payment.payment_method.should_not_receive(:capture)
-          payment.log_entries.should_not_receive(:create)
+          payment.log_entries.should_not_receive(:create!)
           payment.capture!
         end
       end
@@ -293,7 +293,7 @@ describe Spree::Payment do
       end
 
       it "should log the response" do
-        payment.log_entries.should_receive(:create).with(:details => anything)
+        payment.log_entries.should_receive(:create!).with(:details => anything)
         payment.void_transaction!
       end
 
@@ -375,7 +375,7 @@ describe Spree::Payment do
       end
 
       it "should log the response" do
-        payment.log_entries.should_receive(:create).with(:details => anything)
+        payment.log_entries.should_receive(:create!).with(:details => anything)
         payment.credit!
       end
 
@@ -388,7 +388,7 @@ describe Spree::Payment do
 
       context "when response is successful" do
         it "should create an offsetting payment" do
-          Spree::Payment.should_receive(:create)
+          Spree::Payment.should_receive(:create!)
           payment.credit!
         end
 


### PR DESCRIPTION
Closes https://github.com/openfoodfoundation/openfoodnetwork/issues/5449

A failure in creating the refund payment should fail loudly so we see it in Bugsnag. Check out the original commit message for more details.